### PR TITLE
CreatorCube Development Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM node:12.14.1-stretch
+RUN npm install -g eslint prettier

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "CreatorCube Development Container",
+    "dockerFile": "Dockerfile",
+    "appPort": 3000,
+    "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "mikestead.dotenv",
+        "davidanson.vscode-markdownlint",
+        "visualstudioexptteam.vscodeintellicode",
+        "redhat.vscode-xml",
+        "redhat.vscode-yaml",
+    ],
+    "settings": {
+        "#terminal.integrated.defaultProfile.linux#": "/bin/bash"
+    },
+    "postCreateCommand": "yarn install",
+    "runArgs": [
+        "-u",
+        "node"
+    ]
+}


### PR DESCRIPTION
# Summary
Primary VSCode dev container for CreatorCube contributors to quickly set up vscode extensions, npm packages, databases, and anything else they might need while developing on the CreatorCube monorepo. 

It's a source of truth and can be used by the core team to control the developer experience. 

Feel free to add any suggestions or follow up with Dockerfile modifications.

[Learn more about these workspace containers](https://code.visualstudio.com/docs/remote/containers)